### PR TITLE
11 packer kickstart delivery

### DIFF
--- a/.github/workflows/packer-build.yml
+++ b/.github/workflows/packer-build.yml
@@ -8,6 +8,7 @@ jobs:
   build-templates:
     runs-on: ubuntu-latest
     strategy:
+      max-parallel: 1
       matrix:
         node: [ bri-s-01, bri-s-02, bri-s-03 ]
     steps:

--- a/.github/workflows/packer-build.yml
+++ b/.github/workflows/packer-build.yml
@@ -1,8 +1,6 @@
 name: packer-build
 on:
-  push:
-    tags:
-      - "v*"
+  workflow_dispatch:
 
 jobs:
   build-templates:

--- a/.github/workflows/packer-build.yml
+++ b/.github/workflows/packer-build.yml
@@ -46,6 +46,12 @@ jobs:
           sudo wg
           ping 192.168.1.11 -c 3
 
+      - name: Install Packer
+        run: |
+          curl -fsSL https://apt.releases.hashicorp.com/gpg | sudo apt-key add -
+          sudo apt-add-repository "deb [arch=amd64] https://apt.releases.hashicorp.com $(lsb_release -cs) main"
+          sudo apt-get update && sudo apt-get install -y packer
+
       - name: Create SSH key
         run: 'echo "$ANSIBLE_PK" > id_rsa && chmod 600 id_rsa'
         shell: bash
@@ -60,7 +66,7 @@ jobs:
       - name: packer build
         working-directory: packer
         run: |
-          /usr/bin/packer build --force \
+          packer build --force \
           -var "ansible_ssh_password=${{ secrets.ANSIBLE_PASSWORD }}" \
           -var "proxmox_api_token_secret=${{ secrets.PACKER_BRISTOL_PROXMOX_TOKEN_SECRET }}" \
           -var-file="nodes/${{ matrix.node }}.pkrvars.hcl" \

--- a/.github/workflows/packer-build.yml
+++ b/.github/workflows/packer-build.yml
@@ -1,17 +1,50 @@
 name: packer-build
-
 on:
-  workflow_dispatch:
+  push:
+    branches:
+      - "*"
 
 jobs:
   build-templates:
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         node: [ bri-s-01, bri-s-02, bri-s-03 ]
     steps:
       - name: Checkout
         uses: actions/checkout@v3.1.0
+
+      - name: "Install WireGuard"
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y wireguard
+          # https://superuser.com/questions/1500691/usr-bin-wg-quick-line-31-resolvconf-command-not-found-wireguard-debian
+          ln -s /usr/bin/resolvectl /usr/local/bin/resolvconf
+
+      - name: "Create WireGuard config"
+        run: |
+          sudo mkdir -p /etc/wireguard
+          sudo chmod 700 /etc/wireguard
+          sudo touch /etc/wireguard/wg0.conf
+          sudo chmod 600 /etc/wireguard/wg0.conf
+          sudo bash -c "cat > /etc/wireguard/wg0.conf" << EOF
+          [Interface]
+          PrivateKey = ${{ secrets.HL_PKR_PRIVATE_KEY }}
+          Address = 10.1.5.3/32
+          DNS = 10.1.5.1
+          
+          [Peer]
+          PublicKey = 6/tGUsqU3ib5LEEua2cLCUxSDFpiEFhOT0sGkqz0LHk=
+          PresharedKey = ${{ secrets.HL_PKR_PRESHARED_KEY }}
+          AllowedIPs = "10.1.5.1/32,10.1.5.2/32,192.168.1.11/24,10.1.1.1/24,10.1.2.1/24,10.1.3.1/24,0.0.0.0/0"
+          Endpoint = ${{ secrets.HL_ENDPOINT }}
+          EOF
+
+      - name: "Start WireGuard"
+        run: |
+          sudo wg-quick up wg0
+          sudo wg
+          ping 192.168.1.11 -c 3
 
       - name: Create SSH key
         run: 'echo "$ANSIBLE_PK" > id_rsa && chmod 600 id_rsa'
@@ -32,3 +65,9 @@ jobs:
           -var "proxmox_api_token_secret=${{ secrets.PACKER_BRISTOL_PROXMOX_TOKEN_SECRET }}" \
           -var-file="nodes/${{ matrix.node }}.pkrvars.hcl" \
           .
+
+      - name: "Stop WireGuard"
+        if: always()
+        run: |
+          sudo wg-quick down wg0
+          sudo rm -rf /etc/wireguard

--- a/.github/workflows/packer-build.yml
+++ b/.github/workflows/packer-build.yml
@@ -1,8 +1,8 @@
 name: packer-build
 on:
   push:
-    branches:
-      - "*"
+    tags:
+      - "v*"
 
 jobs:
   build-templates:

--- a/.github/workflows/packer-build.yml
+++ b/.github/workflows/packer-build.yml
@@ -1,6 +1,9 @@
 name: packer-build
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - "*"
 
 jobs:
   build-templates:

--- a/.github/workflows/packer-build.yml
+++ b/.github/workflows/packer-build.yml
@@ -59,10 +59,17 @@ jobs:
         env:
           ANSIBLE_PK: ${{ secrets.ANSIBLE_PK }}
 
+      - name: Disable the firewall
+        run: |
+          sudo ufw status
+          sudo ufw disable
+          sudo ufw status
+
       - name: packer init
         working-directory: packer
         run: |
           /usr/bin/packer init .
+
 
       - name: packer build
         working-directory: packer

--- a/.github/workflows/packer-build.yml
+++ b/.github/workflows/packer-build.yml
@@ -36,7 +36,7 @@ jobs:
           [Peer]
           PublicKey = 6/tGUsqU3ib5LEEua2cLCUxSDFpiEFhOT0sGkqz0LHk=
           PresharedKey = ${{ secrets.HL_PKR_PRESHARED_KEY }}
-          AllowedIPs = "10.1.5.1/32,10.1.5.2/32,192.168.1.11/24,10.1.1.1/24,10.1.2.1/24,10.1.3.1/24,0.0.0.0/0"
+          AllowedIPs = 10.1.5.1/32,10.1.5.2/32,192.168.1.11/24,10.1.1.1/24,10.1.2.1/24,10.1.3.1/24,0.0.0.0/0
           Endpoint = ${{ secrets.HL_ENDPOINT }}
           EOF
 

--- a/.github/workflows/template-terraform.yml
+++ b/.github/workflows/template-terraform.yml
@@ -92,6 +92,7 @@ jobs:
 
       - name: "Run the make command"
         run: make ${{ inputs.command }} ARM_ACCESS_KEY=${{ secrets.ARM_ACCESS_KEY }}
+        working-directory: terraform
         env:
           TF_VAR_ansible_id_rsa: ${{ secrets.ANSIBLE_PK }}
           TF_VAR_bristol_proxmox_token_secret: ${{ secrets.BRISTOL_PROXMOX_TOKEN_SECRET }}

--- a/.github/workflows/template-terraform.yml
+++ b/.github/workflows/template-terraform.yml
@@ -32,10 +32,10 @@ on:
       BRISTOL_PROXMOX_TOKEN_SECRET:
         required: true
         description: "The HL Proxmox token secret"
-      HL_PRIVATE_KEY:
+      HL_TF_PRIVATE_KEY:
         required: true
         description: "The HL WireGuard private key"
-      HL_PRESHARED_KEY:
+      HL_TF_PRESHARED_KEY:
         required: true
         description: "The HL WireGuard preshared key"
       HL_ENDPOINT:

--- a/.github/workflows/template-terraform.yml
+++ b/.github/workflows/template-terraform.yml
@@ -66,13 +66,13 @@ jobs:
           sudo chmod 600 /etc/wireguard/wg0.conf
           sudo bash -c "cat > /etc/wireguard/wg0.conf" << EOF
           [Interface]
-          PrivateKey = ${{ secrets.HL_PRIVATE_KEY }}
+          PrivateKey = ${{ secrets.HL_TF_PRIVATE_KEY }}
           Address = ${{ inputs.wg_address }}
           DNS = ${{ inputs.wg_dns }}
           
           [Peer]
           PublicKey = 6/tGUsqU3ib5LEEua2cLCUxSDFpiEFhOT0sGkqz0LHk=
-          PresharedKey = ${{ secrets.HL_PRESHARED_KEY }}
+          PresharedKey = ${{ secrets.HL_TF_PRESHARED_KEY }}
           AllowedIPs = ${{ inputs.wg_allowed_ips }}
           Endpoint = ${{ secrets.HL_ENDPOINT }}
           EOF

--- a/.github/workflows/terraform-apply.yml
+++ b/.github/workflows/terraform-apply.yml
@@ -12,7 +12,7 @@ jobs:
       ARM_ACCESS_KEY: ${{ secrets.ARM_ACCESS_KEY }}
       ANSIBLE_PK: ${{ secrets.ANSIBLE_PK }}
       BRISTOL_PROXMOX_TOKEN_SECRET: ${{ secrets.BRISTOL_PROXMOX_TOKEN_SECRET }}
-      HL_PRIVATE_KEY: ${{ secrets.HL_PRIVATE_KEY }}
-      HL_PRESHARED_KEY: ${{ secrets.HL_PRESHARED_KEY }}
+      HL_TF_PRIVATE_KEY: ${{ secrets.HL_TF_PRIVATE_KEY }}
+      HL_TF_PRESHARED_KEY: ${{ secrets.HL_TF_PRESHARED_KEY }}
       HL_ENDPOINT: ${{ secrets.HL_ENDPOINT }}
       DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/.github/workflows/terraform-destroy.yml
+++ b/.github/workflows/terraform-destroy.yml
@@ -12,7 +12,7 @@ jobs:
       ARM_ACCESS_KEY: ${{ secrets.ARM_ACCESS_KEY }}
       ANSIBLE_PK: ${{ secrets.ANSIBLE_PK }}
       BRISTOL_PROXMOX_TOKEN_SECRET: ${{ secrets.BRISTOL_PROXMOX_TOKEN_SECRET }}
-      HL_PRIVATE_KEY: ${{ secrets.HL_PRIVATE_KEY }}
-      HL_PRESHARED_KEY: ${{ secrets.HL_PRESHARED_KEY }}
+      HL_TF_PRIVATE_KEY: ${{ secrets.HL_TF_PRIVATE_KEY }}
+      HL_TF_PRESHARED_KEY: ${{ secrets.HL_TF_PRESHARED_KEY }}
       HL_ENDPOINT: ${{ secrets.HL_ENDPOINT }}
       DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/.github/workflows/terraform-plan.yml
+++ b/.github/workflows/terraform-plan.yml
@@ -13,7 +13,7 @@ jobs:
       ARM_ACCESS_KEY: ${{ secrets.ARM_ACCESS_KEY }}
       ANSIBLE_PK: ${{ secrets.ANSIBLE_PK }}
       BRISTOL_PROXMOX_TOKEN_SECRET: ${{ secrets.BRISTOL_PROXMOX_TOKEN_SECRET }}
-      HL_PRIVATE_KEY: ${{ secrets.HL_PRIVATE_KEY }}
-      HL_PRESHARED_KEY: ${{ secrets.HL_PRESHARED_KEY }}
+      HL_TF_PRIVATE_KEY: ${{ secrets.HL_TF_PRIVATE_KEY }}
+      HL_TF_PRESHARED_KEY: ${{ secrets.HL_TF_PRESHARED_KEY }}
       HL_ENDPOINT: ${{ secrets.HL_ENDPOINT }}
       DOCKERHUB_PASSWORD: ${{ secrets.DOCKERHUB_PASSWORD }}

--- a/packer/settings.pkr.hcl
+++ b/packer/settings.pkr.hcl
@@ -83,7 +83,7 @@ variable "cloud_init_storage_pool" {
 variable "boot_command" {
   type    = list(string)
   default = [
-    "<up><wait><tab><wait> text inst.ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/rocky8.ks<enter><wait5>"
+    "<up><wait><tab><wait> text inst.ks=http://10.1.5.3:{{ .HTTPPort }}/rocky8.ks<enter><wait5>"
   ]
   description = "Command to send to the template as it starts up"
 }

--- a/terraform/Dockerfile
+++ b/terraform/Dockerfile
@@ -1,3 +1,3 @@
-FROM docker.io/clincha/terraform-provider-proxmox:1.0.14
+FROM docker.io/clincha/terraform-provider-proxmox:1.0.16
 
 COPY . .

--- a/terraform/Dockerfile
+++ b/terraform/Dockerfile
@@ -1,3 +1,3 @@
 FROM docker.io/clincha/terraform-provider-proxmox-azrm:1.0.12
 
-COPY ../terraform .
+COPY . .

--- a/terraform/Dockerfile
+++ b/terraform/Dockerfile
@@ -1,3 +1,3 @@
-FROM docker.io/clincha/terraform-provider-proxmox-azrm:1.0.14
+FROM docker.io/clincha/terraform-provider-proxmox:1.0.14
 
 COPY . .

--- a/terraform/Dockerfile
+++ b/terraform/Dockerfile
@@ -1,3 +1,3 @@
-FROM docker.io/clincha/terraform-provider-proxmox-azrm:1.0.12
+FROM docker.io/clincha/terraform-provider-proxmox-azrm:1.0.14
 
 COPY . .

--- a/terraform/Makefile
+++ b/terraform/Makefile
@@ -11,7 +11,7 @@ all: build plan
 
 build:
 	@echo "Building..."
-	@podman build . --file containers/Dockerfile --tag docker.io/clincha/terraform-init:${VERSION}
+	@podman build . --file Dockerfile --tag docker.io/clincha/terraform-init:${VERSION}
 
 debug: build
 	@echo "Debugging..."

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     proxmox = {
       source  = "telmate/proxmox"
-      version = "1.0.12"
+      version = "1.0.14"
     }
     azurerm = {
       source  = "hashicorp/azurerm"

--- a/terraform/providers.tf
+++ b/terraform/providers.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     proxmox = {
       source  = "telmate/proxmox"
-      version = "1.0.14"
+      version = "1.0.16"
     }
     azurerm = {
       source  = "hashicorp/azurerm"


### PR DESCRIPTION
Closes #11 - Packer now runs over the WireGuard VPN so it can run as a GitHub hosted runner
Closes #20 - This was mostly completed by the previous Terraform work but I've done it here as well
Closes #34 - This was needed a security feature going over the internet. Easy enough to do with the LetsEncrypt certificate
Closes #67 - This is managed using GitHub secrets and BitWarden
Closes #119 - This was resolved by containerising my Terraform runner and building from source directly